### PR TITLE
build enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/js/contrail-charts.js",
   "scripts": {
     "build": "webpack --mode=build",
+    "clean-build": "rm -rf build/* && webpack --mode=build",
     "dev": "webpack --progress --colors --watch --mode=dev",
     "test": "node test.js",
     "lint": "eslint src/** || true"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,44 +7,32 @@ var env = require('yargs').argv.mode
 var fileName = 'contrail-charts'
 var libraryName = 'coCharts'
 var framework = 'backbone'
-
 var plugins = []
-var outputFile
 
 if (env === 'build') {
-  plugins.push(new UglifyJsPlugin({ minimize: true }))
-  outputFile = fileName + '.min.js'
-} else {
-  outputFile = fileName + '.js'
+  plugins.push(new UglifyJsPlugin({
+    include: /\.min\.js$/,
+    minimize: true }))
 }
 
 // Let's put css under css directory.
 plugins.push(new ExtractTextPlugin('css/' + fileName + '.css'))
 
 var config = {
-  entry: path.join(__dirname, '/src/js/contrail-charts/index.js'),
+  entry: {
+    'contrail-charts': path.join(__dirname, '/src/js/contrail-charts/index.js'),
+    'contrail-charts.min': path.join(__dirname, '/src/js/contrail-charts/index.js')
+  },
   devtool: 'source-map',
   output: {
     path: path.join(__dirname, '/build'),
-    filename: 'js/' + outputFile,
+    filename: 'js/' + '[name].js',
     library: libraryName,
     libraryTarget: 'umd',
     umdNamedDefine: false
   },
   module: {
     loaders: [
-      /*
-      {
-        test: /(\.jsx|\.js)$/,
-        loader: 'babel',
-        exclude: /(node_modules|bower_components)/
-      },
-      {
-        test: /(\.jsx|\.js)$/,
-        loader: "eslint-loader",
-        exclude: /node_modules/
-      }
-      */
       {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader')


### PR DESCRIPTION
- on 'npm run build' create both minified and uncompressed files
- uglify plugin looks for .min.js and is enabled only in build env