### PR TITLE
type to use class name without view and configModel suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ To build
 ```
 npm run build
 ```
+to build examples, use
+```
+npm run build-examples
+```
+
 you'll find the `js` and `css` under `build/` directory
 
 Or, download from our releases.
@@ -51,7 +56,7 @@ And we need to plot a line chart for memory 'mem' data over time 'ts'
         container: '#cpumemChart', // Chart container.
         components: [ // Array of child components.
           {
-            type: 'compositeY', // Component type. Let's use composite-y component to render line chart. Refer wiki for more details on component.
+            type: 'CompositeYChart', // Component type. Let's use composite-y component to render line chart. Refer wiki for more details on component.
             config: {
               plot: {
                 x: {
@@ -61,7 +66,7 @@ And we need to plot a line chart for memory 'mem' data over time 'ts'
                 y: [ // Array of plottable accessors on Y axis
                   {
                     accessor: 'mem', // Accessor key from the dataset.
-                    chart: 'line' // Type of the chart
+                    chart: 'LineChart' // Type of the chart
                   }
                 ]
               }
@@ -93,7 +98,7 @@ and use them inside your plot.y config
       {
         accessor: 'mem', // Field name to use on y
         label: 'Memory',
-        chart: 'line', // Type of the chart
+        chart: 'LineChart', // Type of the chart
         axis: y1 // Axis to plot this field on
       }
     ]
@@ -120,13 +125,13 @@ series are different, let's put them on different axis.
     y: [
       {
         accessor: 'mem', // Field name to use on y
-        chart: 'line', // Type of the chart
+        chart: 'LineChart', // Type of the chart
         label: 'Memory', // Label to be displayed on the axis
         axis: y1 // Axis to plot this field on
       },
       {
           accessor: 'cpu', // Field name to use on y
-          chart: 'bar', // Type of the chart
+          chart: 'BarChart', // Type of the chart
           label: 'CPU', // Label to be displayed on the axis
           axis: y2 // Axis to plot this field on
         }

--- a/examples/area/area.js
+++ b/examples/area/area.js
@@ -10,7 +10,7 @@ const simpleChartView = new coCharts.charts.XYChartView()
 simpleChartView.setConfig({
   container: '#simpleChart',
   components: [{
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       plot: {
         x: {
@@ -21,7 +21,7 @@ simpleChartView.setConfig({
           {
             enabled: true,
             accessor: 'y',
-            chart: 'area',
+            chart: 'AreaChart',
             axis: 'y',
           }
         ]

--- a/examples/basic/basic.js
+++ b/examples/basic/basic.js
@@ -14,7 +14,7 @@ const cpuMemChartView = new coCharts.charts.XYChartView()
 cpuMemChartView.setConfig({
   container: '#basicChart',
   components: [{
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       plot: {
         x: {

--- a/examples/composite-xy-timeline/composite-xy-timeline.css
+++ b/examples/composite-xy-timeline/composite-xy-timeline.css
@@ -1,7 +1,6 @@
 #complexChart {
     position: relative;
     margin: 30px;
-    width: 75%;
 }
 
 #complexChart-xyChart {

--- a/examples/composite-xy-timeline/composite-xy-timeline.js
+++ b/examples/composite-xy-timeline/composite-xy-timeline.js
@@ -28,7 +28,7 @@ complexChartView.setConfig({
   container: '#complexChart',
   components: [{
     id: 'complexChartCompositeY',
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -50,13 +50,13 @@ complexChartView.setConfig({
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBar'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y1',
@@ -65,17 +65,17 @@ complexChartView.setConfig({
             accessor: 'b',
             labelFormatter: 'B',
             enabled: true,
-            chart: 'stackedBar',
+            chart: 'stackedBarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y1',
@@ -84,17 +84,17 @@ complexChartView.setConfig({
             accessor: 'c',
             labelFormatter: 'C',
             enabled: false,
-            chart: 'stackedBar',
+            chart: 'StackedBar',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y1',
@@ -104,17 +104,17 @@ complexChartView.setConfig({
             labelFormatter: 'Megabytes',
             color: '#d62728',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart',
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y2',
@@ -124,17 +124,17 @@ complexChartView.setConfig({
             labelFormatter: 'Megabytes',
             color: '#9467bd',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y2',
@@ -159,7 +159,7 @@ complexChartView.setConfig({
       }
     }
   }, {
-    type: 'timeline',
+    type: 'Timeline',
     config: {
       marginInner: 10,
       marginLeft: 80,

--- a/examples/composite-xy/composite-xy.css
+++ b/examples/composite-xy/composite-xy.css
@@ -18,7 +18,7 @@
     margin-bottom: 25px;
 }
 
-#messageView {
+#messageId {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/examples/composite-xy/composite-xy.js
+++ b/examples/composite-xy/composite-xy.js
@@ -39,7 +39,7 @@ complexChartView.setConfig({
     type: 'controlPanel',
     config: {
       menu: [
-        { id: 'Refresh' },
+        { id: 'refresh' },
       ],
     },
   }, {

--- a/examples/composite-xy/composite-xy.js
+++ b/examples/composite-xy/composite-xy.js
@@ -27,7 +27,7 @@ const complexChartView = new coCharts.charts.XYChartView()
 complexChartView.setConfig({
   container: '#complexChart',
   components: [{
-    type: 'legendPanel',
+    type: 'LegendPanel',
     config: {
       sourceComponent: 'complexChartCompositeY',
       placement: 'row',
@@ -36,15 +36,15 @@ complexChartView.setConfig({
       chartSelector: true,
     },
   }, {
-    type: 'controlPanel',
+    type: 'ControlPanel',
     config: {
       menu: [
-        { id: 'refresh' },
+        { id: 'Refresh' },
       ],
     },
   }, {
     id: 'complexChartCompositeY',
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -63,17 +63,17 @@ complexChartView.setConfig({
             accessor: 'a',
             labelFormatter: 'A',
             enabled: true,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBar'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y1',
@@ -82,17 +82,17 @@ complexChartView.setConfig({
             accessor: 'b',
             labelFormatter: 'B',
             enabled: true,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y1',
@@ -101,17 +101,17 @@ complexChartView.setConfig({
             accessor: 'c',
             labelFormatter: 'C',
             enabled: false,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y1',
@@ -121,17 +121,17 @@ complexChartView.setConfig({
             labelFormatter: 'Megabytes',
             color: '#d62728',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y2',
@@ -141,17 +141,17 @@ complexChartView.setConfig({
             labelFormatter: 'Megabytes',
             color: '#9467bd',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
-                chart: 'bar'
+                chart: 'BarChart'
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             axis: 'y2',
@@ -177,7 +177,7 @@ complexChartView.setConfig({
       }
     },
   }, {
-    type: 'navigation',
+    type: 'Navigation',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -196,19 +196,19 @@ complexChartView.setConfig({
             enabled: true,
             accessor: 'a',
             labelFormatter: 'A',
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             axis: 'y1',
           }, {
             enabled: true,
             accessor: 'b',
             labelFormatter: 'B',
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             axis: 'y1',
           }, {
             enabled: true,
             accessor: 'd',
             labelFormatter: 'Megabytes',
-            chart: 'line',
+            chart: 'LineChart',
             axis: 'y2',
           }
         ]
@@ -230,7 +230,7 @@ complexChartView.setConfig({
     },
   }, {
     id: 'defaultTooltip',
-    type: 'tooltip',
+    type: 'Tooltip',
     config: {
       dataConfig: [
         {
@@ -262,19 +262,19 @@ complexChartView.setConfig({
     },
   }, {
     id: 'customTooltip',
-    type: 'tooltip',
+    type: 'Tooltip',
     config: {
       template: (data) => '<div class="tooltip-content">Custom tooltip</div>',
     }
   }, {
-    id: 'messageView',
-    type: 'message',
+    id: 'messageId',
+    type: 'Message',
     config: {
       enabled: true,
     }
   }, {
     id: 'crosshairId',
-    type: 'crosshair',
+    type: 'Crosshair',
     config: {
       tooltip: 'defaultTooltip',
     }
@@ -282,7 +282,7 @@ complexChartView.setConfig({
 })
 complexChartView.setData(complexData)
 complexChartView.renderMessage({
-  componentId: 'XYChartView',
+  componentId: 'XYChart',
   action: 'once',
   messages: [{
     level: 'info',

--- a/examples/control-panel/index.html
+++ b/examples/control-panel/index.html
@@ -12,12 +12,12 @@
 		<script src="../../node_modules/d3/build/d3.js"></script>
 		<link href="../../node_modules/font-awesome/css/font-awesome.min.css" rel="stylesheet">
 		<!-- third-party-libs -->
-		<link href="../../build/css/contrail-charts.css" rel="stylesheet">
+		<link href="../../build/src/css/contrail-charts.css" rel="stylesheet">
 		<link href="./index.css" rel="stylesheet">
 	</head>
 	<body>
 		<div id="chart"></div>
-		<script src="../../build/js/contrail-charts.js"></script>
+		<script src="../../build/src/js/contrail-charts.js"></script>
 		<script src="./index.js"></script>
 	</body>
 </html>

--- a/examples/control-panel/index.js
+++ b/examples/control-panel/index.js
@@ -24,21 +24,21 @@ const complexChartView = new coCharts.charts.XYChartView()
 complexChartView.setConfig({
   container: '#chart',
   components: [{
-    type: 'controlPanel',
+    type: 'ControlPanel',
     config: {
       menu: [{
-        id: 'refresh',
+        id: 'Refresh',
       }, {
-        id: 'filter',
+        id: 'Filter',
         component: 'filterId',
       }, {
-        id: 'colorPicker',
+        id: 'ColorPicker',
         component: 'colorPickerId',
       }],
     }
   }, {
     id: 'compositeYId',
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -56,21 +56,21 @@ complexChartView.setConfig({
             accessor: 'a',
             labelFormatter: 'A',
             enabled: true,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             axis: 'y1',
             tooltip: 'defaultTooltip',
           }, {
             accessor: 'b',
             labelFormatter: 'B',
             enabled: true,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             axis: 'y1',
             tooltip: 'customTooltip',
           }, {
             accessor: 'c',
             labelFormatter: 'C',
             enabled: false,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             axis: 'y1',
             tooltip: 'defaultTooltip',
           }, {
@@ -78,7 +78,7 @@ complexChartView.setConfig({
             labelFormatter: 'Megabytes',
             color: '#d62728',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             axis: 'y2',
             tooltip: 'defaultTooltip',
           }, {
@@ -86,7 +86,7 @@ complexChartView.setConfig({
             labelFormatter: 'Megabytes',
             color: '#9467bd',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             axis: 'y2',
             tooltip: 'defaultTooltip',
           }
@@ -111,14 +111,14 @@ complexChartView.setConfig({
     },
   }, {
     id: 'colorPickerId',
-    type: 'colorPicker',
+    type: 'ColorPicker',
     config: {
       sourceComponent: 'compositeYId',
       embedded: true,
     }
   }, {
     id: 'filterId',
-    type: 'filter',
+    type: 'Filter',
     config: {
       sourceComponent: 'compositeYId',
       embedded: true,

--- a/examples/control-panel/index.js
+++ b/examples/control-panel/index.js
@@ -27,7 +27,7 @@ complexChartView.setConfig({
     type: 'controlPanel',
     config: {
       menu: [{
-        id: 'Refresh',
+        id: 'refresh',
       }, {
         id: 'filter',
         component: 'filterId',

--- a/examples/linebar/linebar.js
+++ b/examples/linebar/linebar.js
@@ -40,13 +40,13 @@ const cpuMemChartView = new coCharts.charts.XYChartView()
 cpuMemChartView.setConfig({
   container: '#cpuMemChart',
   components: [{
-    type: 'legendPanel',
+    type: 'LegendPanel',
     config: {
       sourceComponent: 'cpuMemCompositeY',
     }
   }, {
     id: 'cpuMemCompositeY',
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -65,14 +65,14 @@ cpuMemChartView.setConfig({
             accessor: 'cpu_stats.cpu_one_min_avg',
             label: 'CPU Utilization (%)',
             enabled: true,
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar',
+                chart: 'StackedBarChart',
               }, {
                 label: 'Line',
-                chart: 'line',
+                chart: 'LineChart',
               }
             ],
             color: '#6baed6',
@@ -81,14 +81,14 @@ cpuMemChartView.setConfig({
             accessor: 'cpu_stats.rss',
             label: 'Memory Usage',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'stackedBar',
+                chart: 'StackedBarChart',
               }, {
                 label: 'Line',
-                chart: 'line'
+                chart: 'LineChart'
               }
             ],
             color: '#2ca02c',
@@ -111,7 +111,8 @@ cpuMemChartView.setConfig({
       }
     }
   }, {
-    type: 'navigation',
+    id: 'cpuMemChart-navigation',
+    type: 'Navigation',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -130,14 +131,14 @@ cpuMemChartView.setConfig({
             enabled: true,
             accessor: 'cpu_stats.cpu_one_min_avg',
             labelFormatter: 'CPU',
-            chart: 'stackedBar',
+            chart: 'StackedBarChart',
             color: '#6baed6',
             axis: 'y1',
           }, {
             enabled: true,
             accessor: 'cpu_stats.rss',
             labelFormatter: 'Memory',
-            chart: 'line',
+            chart: 'LineChart',
             color: '#2ca02c',
             axis: 'y2',
           }
@@ -161,7 +162,7 @@ cpuMemChartView.setConfig({
     }
   }, {
     id: 'defaultTooltip',
-    type: 'tooltip',
+    type: 'Tooltip',
     config: {
       dataConfig: [
         {
@@ -181,7 +182,7 @@ cpuMemChartView.setConfig({
     }
   }, {
     id: 'cpuMemChart-controlPanel',
-    type: 'controlPanel',
+    type: 'ControlPanel',
     config: {
       enabled: true,
       buttons: [
@@ -200,18 +201,19 @@ cpuMemChartView.setConfig({
       ]
     }
   }, {
-    type: 'standalone',
+    type: 'Standalone',
     config: {
       isSharedContainer: false,
     },
   }, {
-    type: 'message',
+    id: 'cpuMemChart-message',
+    type: 'Message',
     config: {
       enabled: true,
     }
   }, {
     id: 'crosshairId',
-    type: 'crosshair',
+    type: 'Crosshair',
     config: {
       tooltip: 'defaultTooltip',
     }
@@ -219,7 +221,7 @@ cpuMemChartView.setConfig({
 })
 cpuMemChartView.setData(tsData)
 cpuMemChartView.renderMessage({
-  componentId: 'XYChartView',
+  componentId: 'XYChart',
   action: 'once',
   messages: [{
     level: 'info',

--- a/examples/multi-chart/multi-chart.js
+++ b/examples/multi-chart/multi-chart.js
@@ -14,10 +14,10 @@ for (let i = 0; i < 100; i++) {
 const chartConfigs = [
   {
     chartId: 'chart1',
-    type: 'XYChartView',
+    type: 'XYChart',
     container: '#chart1',
     components: [{
-      type: 'compositeY',
+      type: 'CompositeYChart',
       config: {
         plot: {
           x: {
@@ -28,12 +28,12 @@ const chartConfigs = [
             {
               accessor: 'a',
               enabled: true,
-              chart: 'bar',
+              chart: 'BarChart',
               axis: 'y',
             }, {
               accessor: 'b',
               enabled: true,
-              chart: 'bar',
+              chart: 'BarChart',
               axis: 'y',
             }
           ]
@@ -46,10 +46,10 @@ const chartConfigs = [
     }]
   }, {
     chartId: 'chart2',
-    type: 'XYChartView',
+    type: 'XYChart',
     container: '#chart2',
     components: [{
-      type: 'compositeY',
+      type: 'CompositeYChart',
       config: {
         plot: {
           x: {
@@ -60,14 +60,14 @@ const chartConfigs = [
             {
               accessor: 'c',
               enabled: true,
-              chart: 'line',
+              chart: 'LineChart',
               axis: 'y',
             }
           ]
         }
       },
     }, {
-      type: 'navigation',
+      type: 'Navigation',
       config: {
         chartHeight: 200,
         plot: {
@@ -79,7 +79,7 @@ const chartConfigs = [
             {
               accessor: 'c',
               enabled: true,
-              chart: 'line',
+              chart: 'LineChart',
               axis: 'y',
             }
           ]

--- a/examples/pie/pie.js
+++ b/examples/pie/pie.js
@@ -21,15 +21,15 @@ function getValue (serie) {
 const chartConfig = {
   container: '#chart',
   components: [{
-    type: 'controlPanel',
+    type: 'ControlPanel',
     config: {
       menu: [{
         id: 'Refresh',
       }],
     }
   }, {
-    id: 'pieChart',
-    type: 'pieChart',
+    id: 'pieChartId',
+    type: 'PieChart',
     config: {
       type: 'donut',
       radius: 100,
@@ -43,7 +43,7 @@ const chartConfig = {
     },
   }, {
     id: 'tooltipId',
-    type: 'tooltip',
+    type: 'Tooltip',
     config: {
       dataConfig: [
         {
@@ -54,9 +54,9 @@ const chartConfig = {
       ],
     },
   }, {
-    type: 'legendUniversal',
+    type: 'LegendUniversal',
     config: {
-      sourceComponent: 'pieChart',
+      sourceComponent: 'pieChartId',
     },
   }]
 }

--- a/examples/port-distribution/port-distribution.js
+++ b/examples/port-distribution/port-distribution.js
@@ -68,7 +68,7 @@ const chartConfig = {
             label: 'In Bytes',
             chart: 'scatterPlot',
             sizeAccessor: 'inBytes',
-            sizeAxis: 'rAxis',
+            sizeAxis: 'sizeAxis',
             shape: 'circle',
             axis: 'y1'
           },
@@ -77,7 +77,7 @@ const chartConfig = {
             chart: 'scatterPlot',
             label: 'Out Bytes',
             sizeAccessor: 'outBytes',
-            sizeAxis: 'rAxis',
+            sizeAxis: 'sizeAxis',
             shape: 'triangle',
             axis: 'y2'
           }
@@ -89,8 +89,8 @@ const chartConfig = {
           formatter: numberFormatter,
           labelMargin: 5
         },
-        rAxis: {
-          range: [3, 20]
+        sizeAxis: {
+          range: [3, 500]
         },
         y1: {
           position: 'left',
@@ -182,7 +182,7 @@ const chartConfig = {
             chart: 'scatterPlot',
             axis: 'y1',
             sizeAccessor: 'outBytes',
-            sizeAxis: 'rAxis',
+            sizeAxis: 'sizeAxis',
             shape: 'circle',
           }
         ]
@@ -191,8 +191,8 @@ const chartConfig = {
         x: {
           scale: 'scaleLinear'
         },
-        rAxis: {
-          range: [3, 20]
+        sizeAxis: {
+          range: [3, 500]
         },
         y1: {
           position: 'left',

--- a/examples/port-distribution/port-distribution.js
+++ b/examples/port-distribution/port-distribution.js
@@ -49,7 +49,7 @@ dataSrc = dataProcesser(dataSrc)
 const chartConfig = {
   container: '#chart',
   components: [{
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       chartHeight: 600,
       marginInner: 10,
@@ -66,7 +66,7 @@ const chartConfig = {
           {
             accessor: 'inBytes',
             label: 'In Bytes',
-            chart: 'scatterPlot',
+            chart: 'ScatterPlot',
             sizeAccessor: 'inBytes',
             sizeAxis: 'sizeAxis',
             shape: 'circle',
@@ -74,7 +74,7 @@ const chartConfig = {
           },
           {
             accessor: 'outBytes',
-            chart: 'scatterPlot',
+            chart: 'ScatterPlot',
             label: 'Out Bytes',
             sizeAccessor: 'outBytes',
             sizeAxis: 'sizeAxis',
@@ -105,7 +105,7 @@ const chartConfig = {
       }
     }
   }, {
-    type: 'tooltip',
+    type: 'Tooltip',
     config: {
       title: 'Port Info',
       dataConfig: [
@@ -160,7 +160,7 @@ const chartConfig = {
       ]
     }
   }, {
-    type: 'navigation',
+    type: 'Navigation',
     config: {
       marginInner: 10,
       marginLeft: 80,
@@ -179,7 +179,7 @@ const chartConfig = {
             enabled: true,
             accessor: 'inBytes',
             label: 'In Bytes',
-            chart: 'scatterPlot',
+            chart: 'ScatterPlot',
             axis: 'y1',
             sizeAccessor: 'outBytes',
             sizeAxis: 'sizeAxis',

--- a/examples/requirejs/app/example1.js
+++ b/examples/requirejs/app/example1.js
@@ -25,7 +25,7 @@ define([ // eslint-disable-line no-undef
   complexChartView.setConfig({
     container: '#complexChart',
     components: [{
-      type: 'compositeY',
+      type: 'CompositeYChart',
       config: {
         marginInner: 10,
         marginLeft: 80,
@@ -42,33 +42,33 @@ define([ // eslint-disable-line no-undef
               accessor: 'a',
               label: 'A',
               enabled: true,
-              chart: 'stackedBar',
+              chart: 'StackedBarChart',
               axis: 'y1',
             }, {
               accessor: 'b',
               label: 'B',
               enabled: true,
-              chart: 'stackedBar',
+              chart: 'StackedBarChart',
               axis: 'y1',
             }, {
               accessor: 'c',
               label: 'C',
               enabled: false,
-              chart: 'stackedBar',
+              chart: 'StackedBarChart',
               axis: 'y1',
             }, {
               accessor: 'd',
               label: 'Megabytes',
               color: '#d62728',
               enabled: true,
-              chart: 'line',
+              chart: 'LineChart',
               axis: 'y2',
             }, {
               accessor: 'e',
               label: 'Megabytes',
               color: '#9467bd',
               enabled: true,
-              chart: 'line',
+              chart: 'LineChart',
               axis: 'y2',
             }
           ]
@@ -88,7 +88,7 @@ define([ // eslint-disable-line no-undef
         }
       },
     }, {
-      type: 'tooltip',
+      type: 'Tooltip',
       config: {
         dataConfig: [
           {
@@ -123,7 +123,7 @@ define([ // eslint-disable-line no-undef
   simpleChartView.setConfig({
     container: '#simpleChart',
     components: [{
-      type: 'compositeY',
+      type: 'CompositeYChart',
       config: {
         plot: {
           x: {
@@ -134,7 +134,7 @@ define([ // eslint-disable-line no-undef
             {
               enabled: true,
               accessor: 'y',
-              chart: 'line',
+              chart: 'LineChart',
               axis: 'y',
             }
           ]

--- a/examples/scatterplot/scatterplot.js
+++ b/examples/scatterplot/scatterplot.js
@@ -36,13 +36,13 @@ for (let i = 0; i < 10; i++) {
 const chartConfig = {
   container: '#chart',
   components: [{
-    type: 'legendPanel',
+    type: 'LegendPanel',
     config: {
       sourceComponent: 'scatterPlot',
     },
   }, {
     id: 'scatterPlot',
-    type: 'compositeY',
+    type: 'CompositeYChart',
     config: {
       marginInner: 25,
       plot: {
@@ -54,7 +54,7 @@ const chartConfig = {
           {
             enabled: true,
             accessor: 'data1',
-            chart: 'scatterPlot',
+            chart: 'ScatterPlot',
             sizeAccessor: 'size1',
             sizeAxis: 'sizeAxis',
             shape: 'circle',
@@ -63,7 +63,7 @@ const chartConfig = {
           }, {
             enabled: true,
             accessor: 'data2',
-            chart: 'scatterPlot',
+            chart: 'ScatterPlot',
             sizeAccessor: 'size2',
             sizeAxis: 'sizeAxis',
             shape: 'square',
@@ -72,7 +72,7 @@ const chartConfig = {
           }, {
             enabled: true,
             accessor: 'data3',
-            chart: 'scatterPlot',
+            chart: 'ScatterPlot',
             sizeAccessor: 'size2',
             sizeAxis: 'sizeAxis',
             shape: 'triangle',
@@ -99,7 +99,7 @@ const chartConfig = {
     }
   }, {
     id: 'tooltipId',
-    type: 'tooltip',
+    type: 'Tooltip',
     config: {
       title: 'BUBBLE',
       dataConfig: [
@@ -131,7 +131,7 @@ const chartConfig = {
       ]
     }
   }, {
-    type: 'navigation',
+    type: 'Navigation',
     config: {
       marginInner: 5,
       chartHeight: 200,
@@ -144,7 +144,7 @@ const chartConfig = {
           {
             enabled: true,
             accessor: 'nav',
-            chart: 'line',
+            chart: 'LineChart',
             axis: 'y1',
           }
         ]

--- a/examples/scatterplot/scatterplot.js
+++ b/examples/scatterplot/scatterplot.js
@@ -45,6 +45,7 @@ const chartConfig = {
             sizeAxis: 'rAxis',
             shape: 'circle',
             axis: 'y1',
+            tooltip: 'tooltipId',
           }, {
             enabled: true,
             accessor: 's',
@@ -53,6 +54,7 @@ const chartConfig = {
             sizeAxis: 'rAxis',
             shape: 'square',
             axis: 'y2',
+            tooltip: 'tooltipId',
           }, {
             enabled: true,
             accessor: 't',
@@ -61,6 +63,7 @@ const chartConfig = {
             sizeAxis: 'rAxis',
             shape: 'triangle',
             axis: 'y2',
+            tooltip: 'tooltipId',
           }
         ]
       },

--- a/examples/scatterplot/scatterplot.js
+++ b/examples/scatterplot/scatterplot.js
@@ -11,11 +11,25 @@ const complexData = []
 for (let i = 0; i < 100; i++) {
   complexData.push({
     x: 1475760930000 + 1000000 * i,
-    c: (Math.random() - 0.5) * 50,
-    s: Math.random() * 100,
-    t: Math.random() * 100,
-    r: Math.random() * 10,
+    data1: (Math.random() - 0.5) * 50,
+    data2: Math.random() * 100,
+    data3: Math.random() * 100,
+    size1: Math.random() * 10,
+    size2: Math.random() * 20,
     nav: (Math.random() - 0.5) * 50,
+  })
+}
+
+const staticData = []
+for (let i = 0; i < 10; i++) {
+  staticData.push({
+    x: 1475760930000 + 1000000 * i,
+    data1: (i - 0.5) * 50,
+    data2: i * 100,
+    data3: i * 100,
+    size1: i * 10,
+    size2: i * 20,
+    nav: (i - 0.5) * 50,
   })
 }
 
@@ -39,28 +53,28 @@ const chartConfig = {
         y: [
           {
             enabled: true,
-            accessor: 'c',
+            accessor: 'data1',
             chart: 'scatterPlot',
-            sizeAccessor: 'r',
-            sizeAxis: 'rAxis',
+            sizeAccessor: 'size1',
+            sizeAxis: 'sizeAxis',
             shape: 'circle',
             axis: 'y1',
             tooltip: 'tooltipId',
           }, {
             enabled: true,
-            accessor: 's',
+            accessor: 'data2',
             chart: 'scatterPlot',
-            sizeAccessor: 's',
-            sizeAxis: 'rAxis',
+            sizeAccessor: 'size2',
+            sizeAxis: 'sizeAxis',
             shape: 'square',
             axis: 'y2',
             tooltip: 'tooltipId',
           }, {
             enabled: true,
-            accessor: 't',
+            accessor: 'data3',
             chart: 'scatterPlot',
-            sizeAccessor: 's',
-            sizeAxis: 'rAxis',
+            sizeAccessor: 'size2',
+            sizeAxis: 'sizeAxis',
             shape: 'triangle',
             axis: 'y2',
             tooltip: 'tooltipId',
@@ -68,8 +82,8 @@ const chartConfig = {
         ]
       },
       axis: {
-        rAxis: {
-          range: [3, 50]
+        sizeAxis: {
+          range: [1, 500]
         },
         y1: {
           position: 'left',
@@ -84,6 +98,7 @@ const chartConfig = {
       },
     }
   }, {
+    id: 'tooltipId',
     type: 'tooltip',
     config: {
       title: 'BUBBLE',
@@ -93,20 +108,24 @@ const chartConfig = {
           labelFormatter: 'Time',
           valueFormatter: timeFormatter,
         }, {
-          accessor: 'c',
-          labelFormatter: 'C',
+          accessor: 'data1',
+          labelFormatter: 'Data1',
           valueFormatter: numberFormatter,
         }, {
-          accessor: 's',
-          labelFormatter: 'S',
+          accessor: 'data2',
+          labelFormatter: 'Data2',
           valueFormatter: numberFormatter,
         }, {
-          accessor: 't',
-          labelFormatter: 'T',
+          accessor: 'data3',
+          labelFormatter: 'Data3',
           valueFormatter: numberFormatter,
         }, {
-          accessor: 'r',
-          labelFormatter: 'R',
+          accessor: 'size1',
+          labelFormatter: 'Size1',
+          valueFormatter: numberFormatter,
+        }, {
+          accessor: 'size2',
+          labelFormatter: 'Size2',
           valueFormatter: numberFormatter,
         }
       ]

--- a/src/js/actions/ChangeSelection.js
+++ b/src/js/actions/ChangeSelection.js
@@ -9,7 +9,7 @@ class ChangeSelection extends Action {
 
   _execute (dataProvider) {
     const chart = this._registrar
-    _.each(chart.getComponentsByType('compositeY'), (compositeY) => {
+    _.each(chart.getComponentsByType('CompositeYChart'), (compositeY) => {
       compositeY.changeModel(dataProvider)
     })
   }

--- a/src/js/actions/Refresh.js
+++ b/src/js/actions/Refresh.js
@@ -10,15 +10,15 @@ class Refresh extends Action {
   _execute (accessorName, color) {
     const chart = this._registrar
 
-    _.each(chart.getComponentsByType('compositeY'), (compositeY) => {
+    _.each(chart.getComponentsByType('CompositeYChart'), (compositeY) => {
       compositeY.config.trigger('change', compositeY.config)
     })
 
-    _.each(chart.getComponentsByType('navigation'), (navigation) => {
+    _.each(chart.getComponentsByType('Navigation'), (navigation) => {
       navigation.config.trigger('change', navigation.config)
     })
 
-    _.each(chart.getComponentsByType('pieChart'), (pieChart) => {
+    _.each(chart.getComponentsByType('PieChart'), (pieChart) => {
       pieChart.config.trigger('change', pieChart.config)
     })
   }

--- a/src/js/actions/SelectColor.js
+++ b/src/js/actions/SelectColor.js
@@ -10,7 +10,7 @@ class SelectColor extends Action {
   _execute (accessorName, color) {
     const chart = this._registrar
 
-    _.each(chart.getComponentsByType('compositeY'), (compositeY) => {
+    _.each(chart.getComponentsByType('CompositeYChart'), (compositeY) => {
       const plot = compositeY.config.get('plot')
       const accessor = _.find(plot.y, (a) => a.accessor === accessorName)
       if (accessor) {
@@ -22,7 +22,7 @@ class SelectColor extends Action {
     // Color Picker will be updated as it has CompositeY Config Model as a parent
     // as well as all CompositeY dependant components too
 
-    _.each(chart.getComponentsByType('navigation'), (navigation) => {
+    _.each(chart.getComponentsByType('Navigation'), (navigation) => {
       const plot = navigation.config.get('plot')
       const accessor = _.find(plot.y, (a) => a.accessor === accessorName)
       if (accessor) {

--- a/src/js/actions/SelectSerie.js
+++ b/src/js/actions/SelectSerie.js
@@ -9,7 +9,7 @@ class SelectSerie extends Action {
 
   _execute (accessorName, isSelected) {
     const chart = this._registrar
-    _.each(chart.getComponentsByType('compositeY'), (compositeY) => {
+    _.each(chart.getComponentsByType('CompositeYChart'), (compositeY) => {
       const plot = compositeY.config.get('plot')
       const accessor = _.find(plot.y, (a) => a.accessor === accessorName)
       if (accessor) {
@@ -21,7 +21,7 @@ class SelectSerie extends Action {
     // Filter will be updated as it has CompositeY Config Model as a parent
     // as well as all CompositeY dependant components too
 
-    _.each(chart.getComponentsByType('navigation'), (navigation) => {
+    _.each(chart.getComponentsByType('Navigation'), (navigation) => {
       const plot = navigation.config.get('plot')
       const accessor = _.find(plot.y, (a) => a.accessor === accessorName)
       if (accessor) {

--- a/src/js/charts/multi-chart/MultiChartView.js
+++ b/src/js/charts/multi-chart/MultiChartView.js
@@ -6,8 +6,8 @@ const ContrailChartsView = require('contrail-charts-view')
 // Todo doesn't work. loop issue.
 // const charts = require('charts/index')
 const charts = {
-  XYChartView: require('charts/xy-chart/XYChartView'),
-  RadialChartView: require('charts/radial-chart/RadialChartView'),
+  XYChart: require('charts/xy-chart/XYChartView'),
+  RadialChart: require('charts/radial-chart/RadialChartView'),
 }
 const components = require('components/index')
 
@@ -71,21 +71,17 @@ class ChartView extends ContrailChartsView {
     _.each(this._config.components, (component) => {
       this._registerComponent(component.type, component.config, this._dataProvider, component.id)
     })
-    if (this._isEnabledComponent('navigation')) {
-      const dataModel = this.getComponentsByType('navigation')[0].focusDataProvider
-      _.each(this.getComponentsByType('compositeY'), (compositeY) => compositeY.changeModel(dataModel))
-    }
   }
 
   _registerComponent (type, config, model, id) {
     if (!this._isEnabledComponent(type)) return false
-    const configModel = new components[type].ConfigModel(config)
+    const configModel = new components[`${type}ConfigModel`](config)
     const viewOptions = _.extend(config, {
       id: id,
       config: configModel,
       model: model,
     })
-    const component = new components[type].View(viewOptions)
+    const component = new components[`${type}View`](viewOptions)
     this._components.push(component)
 
     return component

--- a/src/js/charts/radial-chart/RadialChartView.js
+++ b/src/js/charts/radial-chart/RadialChartView.js
@@ -18,7 +18,6 @@ const _actions = [
 * TODO merge with ChartView as long as XYChart too
 */
 class RadialChartView extends ContrailView {
-  get type () { return 'RadialChartView' }
 
   constructor (p = {}) {
     super(p)
@@ -53,9 +52,6 @@ class RadialChartView extends ContrailView {
   setConfig (config) {
     this._config = config
     this.setElement(config.container)
-    if (!this._config.chartId) {
-      this._config.chartId = 'RadialChartView'
-    }
     this._initComponents()
   }
 
@@ -90,7 +86,7 @@ class RadialChartView extends ContrailView {
 
   _registerComponent (type, config, model, id) {
     if (!this._isEnabledComponent(type)) return false
-    const configModel = new components[type].ConfigModel(config)
+    const configModel = new components[`${type}ConfigModel`](config)
     const viewOptions = _.extend(config, {
       id: id,
       config: configModel,
@@ -98,7 +94,7 @@ class RadialChartView extends ContrailView {
       actionman: this._actionman,
       container: this.el,
     })
-    const component = new components[type].View(viewOptions)
+    const component = new components[`${type}View`](viewOptions)
     this._components.push(component)
 
     return component

--- a/src/js/charts/xy-chart/XYChartView.js
+++ b/src/js/charts/xy-chart/XYChartView.js
@@ -20,7 +20,6 @@ const _actions = [
 * Many different Y axis may be configured.
 */
 class XYChartView extends ContrailChartsView {
-  get type () { return 'XYChartView' }
 
   constructor (p) {
     super(p)
@@ -55,9 +54,6 @@ class XYChartView extends ContrailChartsView {
   setConfig (config) {
     this._config = config
     this.setElement(config.container)
-    if (!this._config.chartId) {
-      this._config.chartId = 'XYChartView'
-    }
     // Todo make dataConfig part of handlers? as dataProvider
     if (this._config.dataConfig) this.setDataConfig(this._config.dataConfig)
     this._initComponents()
@@ -125,11 +121,11 @@ class XYChartView extends ContrailChartsView {
         const sourceComponent = this.getComponent(sourceComponentId)
         component.config.parent = sourceComponent.config
       }
-      if (this._isEnabledComponent('tooltip')) {
-        component.config.toggleComponent('tooltip', true)
+      if (this._isEnabledComponent('Tooltip')) {
+        component.config.toggleComponent('Tooltip', true)
       }
-      if (this._isEnabledComponent('crosshair')) {
-        component.config.toggleComponent('crosshair', true)
+      if (this._isEnabledComponent('Crosshair')) {
+        component.config.toggleComponent('Crosshair', true)
       }
     })
   }
@@ -142,8 +138,8 @@ class XYChartView extends ContrailChartsView {
   _registerComponent (type, config, model, id) {
     if (!this._isEnabledComponent(type)) return false
     let configModel
-    if (components[type].ConfigModel) {
-      configModel = new components[type].ConfigModel(config)
+    if (components[`${type}ConfigModel`]) {
+      configModel = new components[`${type}ConfigModel`](config)
     }
     const viewOptions = _.extend({}, config, {
       id: id,
@@ -153,7 +149,7 @@ class XYChartView extends ContrailChartsView {
       // actionman is passed as parameter to each component for it to be able to register action
       actionman: this._actionman,
     })
-    const component = new components[type].View(viewOptions)
+    const component = new components[`${type}View`](viewOptions)
     this._components.push(component)
 
     return component

--- a/src/js/components/color-picker/ColorPickerView.js
+++ b/src/js/components/color-picker/ColorPickerView.js
@@ -5,7 +5,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const _template = require('./color-picker.html')
 
 class ColorPickerView extends ContrailChartsView {
-  get type () { return 'colorPicker' }
   get className () { return 'coCharts-color-picker-view' }
   get events () {
     return {

--- a/src/js/components/composite-y/AreaChartView.js
+++ b/src/js/components/composite-y/AreaChartView.js
@@ -9,7 +9,6 @@ const XYChartSubView = require('components/composite-y/XYChartSubView')
 * This is the child view for CompositeYChartView.
 */
 class AreaChartView extends XYChartSubView {
-  get type () { return 'area' }
   get className () { return 'area-chart' }
   get zIndex () { return 50 }
   get events () {

--- a/src/js/components/composite-y/CompositeYChartConfigModel.js
+++ b/src/js/components/composite-y/CompositeYChartConfigModel.js
@@ -58,10 +58,10 @@ class CompositeYChartConfigModel extends ContrailChartsConfigModel {
    */
   toggleComponent (type, enable) {
     switch (type) {
-      case 'tooltip':
+      case 'Tooltip':
         if (!this.attributes.crosshairEnabled) this.set('tooltipEnabled', enable, {silent: true})
         break
-      case 'crosshair':
+      case 'Crosshair':
         this.set('tooltipEnabled', !enable, {silent: true})
         this.set('crosshairEnabled', enable, {silent: true})
         break

--- a/src/js/components/composite-y/CompositeYChartView.js
+++ b/src/js/components/composite-y/CompositeYChartView.js
@@ -13,16 +13,15 @@ const ScatterPlotView = require('components/composite-y/ScatterPlotView')
 const CompositeYChartConfigModel = require('components/composite-y/CompositeYChartConfigModel')
 
 class CompositeYChartView extends ContrailChartsView {
-  get type () { return 'compositeY' }
   get tagName () { return 'g' }
   get className () { return 'coCharts-xy-chart' }
   get possibleChildViews () {
     return {
-      line: LineChartView,
-      area: AreaChartView,
-      bar: BarChartView,
-      stackedBar: StackedBarChartView,
-      scatterPlot: ScatterPlotView,
+      LineChart: LineChartView,
+      AreaChart: AreaChartView,
+      BarChart: BarChartView,
+      StackedBarChart: StackedBarChartView,
+      ScatterPlot: ScatterPlotView,
     }
   }
 

--- a/src/js/components/composite-y/GroupedBarChartView.js
+++ b/src/js/components/composite-y/GroupedBarChartView.js
@@ -6,7 +6,6 @@ const d3 = require('d3')
 const XYChartSubView = require('components/composite-y/XYChartSubView')
 
 class BarChartView extends XYChartSubView {
-  get type () { return 'bar' }
   get className () { return 'bar-chart' }
   get zIndex () { return 1 }
   get events () {

--- a/src/js/components/composite-y/LineChartView.js
+++ b/src/js/components/composite-y/LineChartView.js
@@ -13,7 +13,6 @@ const XYChartSubView = require('components/composite-y/XYChartSubView')
 * This is the child view for CompositeYChartView.
 */
 class LineChartView extends XYChartSubView {
-  get type () { return 'line' }
   get className () { return 'line-chart' }
   get zIndex () { return 2 }
   get events () {

--- a/src/js/components/composite-y/ScatterPlotView.js
+++ b/src/js/components/composite-y/ScatterPlotView.js
@@ -132,7 +132,7 @@ class ScatterPlotView extends XYChartSubView {
         left: d.x,
         top: d.y,
       }
-      this._actionman.fire('ShowTooltip', offset, d.data, d.accessor.tooltip)
+      this._actionman.fire('ShowComponent', d.accessor.tooltip, offset, d.data)
     }
   }
 
@@ -140,7 +140,7 @@ class ScatterPlotView extends XYChartSubView {
     if (this.config.get('tooltipEnabled')) {
       this.d3.select(() => el)
         .classed('active', false)
-      this._actionman.fire('HideTooltip', d.accessor.tooltip)
+      this._actionman.fire('HideComponent', d.accessor.tooltip)
     }
   }
 }

--- a/src/js/components/composite-y/ScatterPlotView.js
+++ b/src/js/components/composite-y/ScatterPlotView.js
@@ -9,7 +9,6 @@ const d3Scale = require('d3-scale')
 const XYChartSubView = require('components/composite-y/XYChartSubView')
 
 class ScatterPlotView extends XYChartSubView {
-  get type () { return 'scatterPlot' }
   get className () { return 'coCharts-scatter-plot' }
   get zIndex () { return 1 }
 

--- a/src/js/components/composite-y/ScatterPlotView.js
+++ b/src/js/components/composite-y/ScatterPlotView.js
@@ -4,7 +4,6 @@
 const _ = require('lodash')
 require('d3-transition')
 const d3Shape = require('d3-shape')
-const d3Array = require('d3-array')
 const d3Ease = require('d3-ease')
 const d3Scale = require('d3-scale')
 const XYChartSubView = require('components/composite-y/XYChartSubView')
@@ -48,17 +47,8 @@ class ScatterPlotView extends XYChartSubView {
         domains[accessor.sizeAxis] = domains[accessor.sizeAxis].concat(this.model.getRangeFor(accessor.sizeAccessor))
       }
     })
-    _.each(domains, (domain, key) => {
-      domains[key] = d3Array.extent(domain)
-    })
-    this.params.handledAxisNames = _.keys(domains)
     return domains
   }
-  /**
-   * Called by the parent when all scales have been saved in this child's params.
-   * Can be used by the child to perform any additional calculations.
-   */
-  calculateScales () {}
 
   render () {
     _.defer(() => { this._render() })
@@ -73,26 +63,19 @@ class ScatterPlotView extends XYChartSubView {
 
     points.enter()
       .append('path')
-      .attr('class', 'point')
+      .classed('point', true)
       .attr('d', (d) => {
-        return d3Shape.symbol().type(d.shape).size(1)()
+        return d3Shape.symbol().type(d.shape).size(d.area)()
       })
       .attr('transform', (d) => `translate(${d.x},${d.y})`)
       .attr('fill', (d) => d.color)
-      .transition().ease(d3Ease.easeLinear).duration(this.params.duration)
-      .attr('d', (d) => d3Shape.symbol().type(d.shape).size(d.area)())
 
     // Update
     points
       .transition().ease(d3Ease.easeLinear).duration(this.params.duration)
       .attr('transform', (d) => `translate(${d.x},${d.y})`)
 
-    points.exit()
-      .transition()
-      .ease(d3Ease.easeLinear)
-      .duration(this.params.duration)
-      .attr('r', 0)
-      .remove()
+    points.exit().remove()
   }
   /**
    * Create a flat data structure
@@ -101,18 +84,16 @@ class ScatterPlotView extends XYChartSubView {
     const flatData = []
     _.map(this.model.data, (d) => {
       const x = d[this.params.plot.x.accessor]
-      _.each(this.params.activeAccessorData, (accessor) => {
+      _.each(this.params.activeAccessorData, accessor => {
         const key = accessor.accessor
         const y = d[key]
-        const rScale = this.params.axis[accessor.sizeAxis].scale
+        const sizeScale = this.params.axis[accessor.sizeAxis].scale
         const obj = {
           id: x + '-' + key,
-          className: 'point point-' + key,
-          selectClassName: '.point-' + key,
           x: this.xScale(x),
           y: this.yScale(y),
           shape: this.shapeScale(accessor.shape),
-          area: 4 * rScale(d[accessor.sizeAccessor]) * rScale(d[accessor.sizeAccessor]),
+          area: sizeScale(d[accessor.sizeAccessor]),
           color: this.getColor(accessor),
           accessor: accessor,
           data: d,

--- a/src/js/components/composite-y/StackedBarChartView.js
+++ b/src/js/components/composite-y/StackedBarChartView.js
@@ -6,7 +6,6 @@ const d3 = require('d3')
 const XYChartSubView = require('components/composite-y/XYChartSubView')
 
 class StackedBarChartView extends XYChartSubView {
-  get type () { return 'stackedBar' }
   get className () { return 'bar-chart' }
   get zIndex () { return 1 }
   get events () {

--- a/src/js/components/control-panel/ControlPanelView.js
+++ b/src/js/components/control-panel/ControlPanelView.js
@@ -9,7 +9,7 @@ const _template = require('./control-panel.html')
 const _panelTemplate = require('./panel.html')
 const _actionTemplate = require('./action.html')
 const _menuItems = {
-  Refresh: {
+  refresh: {
     title: 'Refresh chart',
     icon: 'fa fa-refresh',
   },

--- a/src/js/components/control-panel/ControlPanelView.js
+++ b/src/js/components/control-panel/ControlPanelView.js
@@ -9,22 +9,21 @@ const _template = require('./control-panel.html')
 const _panelTemplate = require('./panel.html')
 const _actionTemplate = require('./action.html')
 const _menuItems = {
-  refresh: {
+  Refresh: {
     title: 'Refresh chart',
     icon: 'fa fa-refresh',
   },
-  colorPicker: {
+  ColorPicker: {
     title: 'Select color for serie',
     icon: 'fa fa-eyedropper',
   },
-  filter: {
+  Filter: {
     title: 'Select serie to show',
     icon: 'fa fa-filter',
   }
 }
 
 class ControlPanelView extends ContrailChartsView {
-  get type () { return 'controlPanel' }
   get className () { return 'coCharts-control-panel' }
   get events () {
     return {

--- a/src/js/components/crosshair/CrosshairView.js
+++ b/src/js/components/crosshair/CrosshairView.js
@@ -5,7 +5,6 @@ const d3 = require('d3')
 const ContrailChartsView = require('contrail-charts-view')
 
 class CrosshairView extends ContrailChartsView {
-  get type () { return 'crosshair' }
   get tagName () { return 'g' }
   get className () { return 'coCharts-crosshair-view' }
   get zIndex () { return 9 }

--- a/src/js/components/filter/FilterView.js
+++ b/src/js/components/filter/FilterView.js
@@ -6,7 +6,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const _template = require('./filter.html')
 
 class FilterView extends ContrailChartsView {
-  get type () { return 'filter' }
   get className () { return 'coCharts-filter-view' }
   get events () {
     return {

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -1,87 +1,30 @@
-const ControlPanelConfigModel = require('components/control-panel/ControlPanelConfigModel')
-const ControlPanelView = require('components/control-panel/ControlPanelView')
-const FilterView = require('components/filter/FilterView')
-const FilterConfigModel = require('components/filter/FilterConfigModel')
-const MessageConfigModel = require('components/message/MessageConfigModel')
-const MessageView = require('components/message/MessageView')
-const NavigationConfigModel = require('components/navigation/NavigationConfigModel')
-const NavigationView = require('components/navigation/NavigationView')
-const TimelineConfigModel = require('components/timeline/TimelineConfigModel')
-const TimelineView = require('components/timeline/TimelineView')
-const TooltipConfigModel = require('components/tooltip/TooltipConfigModel')
-const TooltipView = require('components/tooltip/TooltipView')
-const LegendConfigModel = require('components/legend/LegendConfigModel')
-const LegendView = require('components/legend/LegendView')
-const LegendUniversalConfigModel = require('components/legend-universal/LegendConfigModel')
-const LegendUniversalView = require('components/legend-universal/LegendView')
-const CrosshairConfigModel = require('components/crosshair/CrosshairConfigModel')
-const CrosshairView = require('components/crosshair/CrosshairView')
-const ColorPickerConfigModel = require('components/color-picker/ColorPickerConfigModel')
-const ColorPickerView = require('components/color-picker/ColorPickerView')
-const CompositeYChartConfigModel = require('components/composite-y/CompositeYChartConfigModel')
-const CompositeYChartView = require('components/composite-y/CompositeYChartView')
-const PieChartConfigModel = require('components/radial/PieChartConfigModel')
-const PieChartView = require('components/radial/PieChartView')
-const StandaloneConfigModel = require('components/standalone/StandaloneConfigModel')
-const StandaloneView = require('components/standalone/StandaloneView')
-var LegendPanelConfigModel = require('components/legend-panel/LegendPanelConfigModel')
-var LegendPanelView = require('components/legend-panel/LegendPanelView')
-
 module.exports = {
-  tooltip: {
-    ConfigModel: TooltipConfigModel,
-    View: TooltipView,
-  },
-  legend: {
-    ConfigModel: LegendConfigModel,
-    View: LegendView,
-  },
-  legendUniversal: {
-    ConfigModel: LegendUniversalConfigModel,
-    View: LegendUniversalView,
-  },
-  legendPanel: {
-    ConfigModel: LegendPanelConfigModel,
-    View: LegendPanelView
-  },
-  crosshair: {
-    ConfigModel: CrosshairConfigModel,
-    View: CrosshairView,
-  },
-  colorPicker: {
-    ConfigModel: ColorPickerConfigModel,
-    View: ColorPickerView,
-  },
-  navigation: {
-    ConfigModel: NavigationConfigModel,
-    View: NavigationView,
-  },
-  filter: {
-    ConfigModel: FilterConfigModel,
-    View: FilterView,
-  },
-  timeline: {
-    ConfigModel: TimelineConfigModel,
-    View: TimelineView,
-  },
-  message: {
-    ConfigModel: MessageConfigModel,
-    View: MessageView,
-  },
-  controlPanel: {
-    ConfigModel: ControlPanelConfigModel,
-    View: ControlPanelView,
-  },
-  compositeY: {
-    ConfigModel: CompositeYChartConfigModel,
-    View: CompositeYChartView,
-  },
-  pieChart: {
-    ConfigModel: PieChartConfigModel,
-    View: PieChartView,
-  },
-  standalone: {
-    ConfigModel: StandaloneConfigModel,
-    View: StandaloneView,
-  },
+  ControlPanelConfigModel: require('components/control-panel/ControlPanelConfigModel'),
+  ControlPanelView: require('components/control-panel/ControlPanelView'),
+  FilterView: require('components/filter/FilterView'),
+  FilterConfigModel: require('components/filter/FilterConfigModel'),
+  MessageConfigModel: require('components/message/MessageConfigModel'),
+  MessageView: require('components/message/MessageView'),
+  NavigationConfigModel: require('components/navigation/NavigationConfigModel'),
+  NavigationView: require('components/navigation/NavigationView'),
+  TimelineConfigModel: require('components/timeline/TimelineConfigModel'),
+  TimelineView: require('components/timeline/TimelineView'),
+  TooltipConfigModel: require('components/tooltip/TooltipConfigModel'),
+  TooltipView: require('components/tooltip/TooltipView'),
+  LegendConfigModel: require('components/legend/LegendConfigModel'),
+  LegendView: require('components/legend/LegendView'),
+  LegendUniversalConfigModel: require('components/legend-universal/LegendConfigModel'),
+  LegendUniversalView: require('components/legend-universal/LegendView'),
+  CrosshairConfigModel: require('components/crosshair/CrosshairConfigModel'),
+  CrosshairView: require('components/crosshair/CrosshairView'),
+  ColorPickerConfigModel: require('components/color-picker/ColorPickerConfigModel'),
+  ColorPickerView: require('components/color-picker/ColorPickerView'),
+  CompositeYChartConfigModel: require('components/composite-y/CompositeYChartConfigModel'),
+  CompositeYChartView: require('components/composite-y/CompositeYChartView'),
+  PieChartConfigModel: require('components/radial/PieChartConfigModel'),
+  PieChartView: require('components/radial/PieChartView'),
+  StandaloneConfigModel: require('components/standalone/StandaloneConfigModel'),
+  StandaloneView: require('components/standalone/StandaloneView'),
+  LegendPanelConfigModel: require('components/legend-panel/LegendPanelConfigModel'),
+  LegendPanelView: require('components/legend-panel/LegendPanelView'),
 }

--- a/src/js/components/legend-panel/LegendPanelView.js
+++ b/src/js/components/legend-panel/LegendPanelView.js
@@ -2,7 +2,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const _template = require('./legend.html')
 
 class LegendPanelView extends ContrailChartsView {
-  get type () { return 'legendPanel' }
   get className () { return 'legend-panel' }
   get events () {
     return {

--- a/src/js/components/legend-universal/LegendView.js
+++ b/src/js/components/legend-universal/LegendView.js
@@ -5,7 +5,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const _template = require('./legend.html')
 
 class LegendView extends ContrailChartsView {
-  get type () { return 'legendUniversal' }
   get className () { return 'coCharts-legend-view' }
 
   constructor (p) {

--- a/src/js/components/legend/LegendView.js
+++ b/src/js/components/legend/LegendView.js
@@ -5,7 +5,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const _template = require('./legend.html')
 
 class LegendView extends ContrailChartsView {
-  get type () { return 'legend' }
   get className () { return 'coCharts-legend-view' }
 
   constructor (p) {

--- a/src/js/components/message/MessageView.js
+++ b/src/js/components/message/MessageView.js
@@ -10,7 +10,6 @@ const _actions = [
 ]
 
 class MessageView extends ContrailChartsView {
-  get type () { return 'message' }
   get className () { return 'coCharts-message-view' }
   get selectors () {
     return _.extend(super.selectors, {

--- a/src/js/components/navigation/NavigationView.js
+++ b/src/js/components/navigation/NavigationView.js
@@ -10,7 +10,6 @@ const CompositeYChartConfigModel = require('components/composite-y/CompositeYCha
 const Selection = require('handlers/Selection')
 
 class NavigationView extends ContrailChartsView {
-  get type () { return 'navigation' }
   get className () { return 'navigation-view' }
   get events () {
     return {

--- a/src/js/components/radial/PieChartConfigModel.js
+++ b/src/js/components/radial/PieChartConfigModel.js
@@ -13,7 +13,7 @@ class PieChartConfigModel extends ContrailChartsConfigModel {
       // The chart width. If not provided will be caculated by View.
       chartWidth: undefined,
 
-      // / The chart height. If not provided will be caculated by View.
+      // The chart height. If not provided will be caculated by View.
       chartHeight: undefined,
 
       colorScale: d3.scaleOrdinal(d3.schemeCategory20),

--- a/src/js/components/radial/PieChartView.js
+++ b/src/js/components/radial/PieChartView.js
@@ -6,7 +6,6 @@ const shape = require('d3-shape')
 const ContrailChartsView = require('contrail-charts-view')
 
 class PieChartView extends ContrailChartsView {
-  get type () { return 'pieChart' }
   get tagName () { return 'g' }
   get className () { return 'coCharts-pie-chart' }
   get events () {

--- a/src/js/components/radial/PieChartView.js
+++ b/src/js/components/radial/PieChartView.js
@@ -30,19 +30,6 @@ class PieChartView extends ContrailChartsView {
     this.listenTo(this.model, 'change', this._onDataModelChange)
   }
 
-  _calculateDimensions () {
-    if (!this.params.chartWidth) {
-      this.params.chartWidth = this._container.getBoundingClientRect().width
-    }
-    if (this.params.chartWidthDelta) {
-      this.params.chartWidth += this.params.chartWidthDelta
-    }
-    if (!this.params.chartHeight) {
-      this.params.chartHeight = Math.round(this.params.chartWidth / 2)
-    }
-    // TODO: use the 'axis' param to compute additional margins for the axis
-  }
-
   render () {
     this.resetParams()
     this._calculateDimensions()
@@ -68,6 +55,19 @@ class PieChartView extends ContrailChartsView {
       .classed('arc', true)
       .attr('d', arc)
       .style('fill', (d) => this.config.getColor(serieConfig.getLabel(d.data)))
+  }
+
+  _calculateDimensions () {
+    if (!this.params.chartWidth) {
+      this.params.chartWidth = this._container.getBoundingClientRect().width
+    }
+    if (this.params.chartWidthDelta) {
+      this.params.chartWidth += this.params.chartWidthDelta
+    }
+    if (!this.params.chartHeight) {
+      this.params.chartHeight = Math.round(this.params.chartWidth / 2)
+    }
+    // TODO: use the 'axis' param to compute additional margins for the axis
   }
 
   // Event handlers

--- a/src/js/components/standalone/StandaloneView.js
+++ b/src/js/components/standalone/StandaloneView.js
@@ -4,7 +4,6 @@
 const ContrailChartsView = require('contrail-charts-view')
 
 class StandaloneView extends ContrailChartsView {
-  get type () { return 'standalone' }
   get tagName () { return 'g' }
   get className () { return 'coCharts-standalone' }
 

--- a/src/js/components/timeline/TimelineView.js
+++ b/src/js/components/timeline/TimelineView.js
@@ -8,7 +8,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const DataProvider = require('handlers/DataProvider')
 
 class TimelineView extends ContrailChartsView {
-  get type () { return 'timeline' }
   get tagName () { return 'g' }
   get className () { return 'timeline-view' }
 

--- a/src/js/components/tooltip/TooltipView.js
+++ b/src/js/components/tooltip/TooltipView.js
@@ -7,7 +7,6 @@ const ContrailChartsView = require('contrail-charts-view')
 const _template = require('./tooltip.html')
 
 class TooltipView extends ContrailChartsView {
-  get type () { return 'tooltip' }
   get className () { return 'coCharts-tooltip-view' }
 
   constructor (p) {

--- a/src/js/handlers/BindingHandler.js
+++ b/src/js/handlers/BindingHandler.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
+ */
+var _ = require('lodash')
+var ContrailModel = require('contrail-model')
+
+class BindingHandler extends ContrailModel {
+  get defaults () {
+    return {
+      charts: {},
+      bindings: [],
+    }
+  }
+  /**
+  * Saves information about a component in a chart.
+  * This information will be used later in order to perform bindings defined in a configuration.
+  */
+  addComponent (chartId = 'default', componentName, component) {
+    var savedChart = this.get('charts')[chartId]
+    if (!savedChart) {
+      savedChart = this.get('charts')[chartId] = {}
+    }
+    var savedComponent = savedChart[componentName] = {}
+    savedComponent.config = component.config
+    savedComponent.model = component.model
+    savedComponent.events = component.eventObject
+  }
+
+  addBindings (bindings, defaultChartId) {
+    defaultChartId = defaultChartId || 'default'
+    _.each(bindings, (binding) => {
+      if (!binding.sourceChart) {
+        binding.sourceChart = defaultChartId
+      }
+      if (!binding.targetChart) {
+        binding.targetChart = defaultChartId
+      }
+      this.get('bindings').push(binding)
+    })
+  }
+
+  performSync (sourceModel, sourcePath, targetModel) {
+    targetModel.set(sourcePath, sourceModel.get(sourcePath))
+    if (_.isObject(sourceModel.get(sourcePath))) {
+      // Perform manual event trigger.
+      targetModel.trigger('change')
+      targetModel.trigger('change:' + sourcePath)
+    }
+    this.listenToOnce(sourceModel, 'change:' + sourcePath, () => {
+      this.performSync(sourceModel, sourcePath, targetModel)
+    })
+  }
+  /**
+  * Set all the bindings defined in the config.
+  */
+  start () {
+    var charts = this.get('charts')
+    _.each(this.get('bindings'), (binding) => {
+      if (!binding.sourceChart && _.keys(charts).length === 1) {
+        binding.sourceChart = _.keys(charts)[0]
+      }
+      if (!binding.targetChart && _.keys(charts).length === 1) {
+        binding.targetChart = _.keys(charts)[0]
+      }
+      if (_.has(charts, binding.sourceChart) && _.has(charts, binding.targetChart)) {
+        if (_.has(charts[binding.sourceChart], binding.sourceComponent) && _.has(charts[binding.targetChart], binding.targetComponent)) {
+          if (_.has(charts[binding.sourceChart][binding.sourceComponent], binding.sourceModel) && _.has(charts[binding.targetChart][binding.targetComponent], binding.targetModel)) {
+            var sourceModel = charts[binding.sourceChart][binding.sourceComponent][binding.sourceModel]
+            var targetModel = charts[binding.targetChart][binding.targetComponent][binding.targetModel]
+            if (binding.action === 'sync') {
+              // Two way listen for changes and perform sync on startup.
+              this.performSync(sourceModel, binding.sourcePath, targetModel)
+              this.performSync(targetModel, binding.sourcePath, sourceModel)
+            } else if (_.isFunction(binding.action)) {
+              this.listenTo(sourceModel, binding.sourcePath, _.partial(binding.action, sourceModel, targetModel))
+            }
+          }
+        }
+      }
+    })
+  }
+}
+
+module.exports = BindingHandler

--- a/src/js/plugins/backbone/ContrailView.js
+++ b/src/js/plugins/backbone/ContrailView.js
@@ -20,7 +20,14 @@ d3.selection.prototype.delegate = function (eventName, targetSelector, handler) 
 }
 
 class ContrailView extends Backbone.View {
+  /**
+   * @return {String} this class name without 'View'
+   */
+  get type () {
+    return this.constructor.name.slice(0, -4)
+  }
   get delegateEventSplitter () { return /^(\S+)\s*(.*)$/ }
+
   // TODO move this function to Utils?
   // instanceof SVGElement works for existing element
   isTagNameSvg (tagName) {

--- a/src/js/plugins/contrail/ContrailChartsConfigModel.js
+++ b/src/js/plugins/contrail/ContrailChartsConfigModel.js
@@ -6,6 +6,12 @@ const ContrailModel = require('contrail-model')
 
 class ContrailChartsConfigModel extends ContrailModel {
   /**
+   * @return {String} this class name without 'ConfigModel'
+   */
+  get type () {
+    return this.constructor.name.slice(0, -11)
+  }
+  /**
   * Initialize the computed parameters with the config parameters.
   */
   computeParams () {

--- a/src/js/plugins/contrail/ContrailChartsUtils.js
+++ b/src/js/plugins/contrail/ContrailChartsUtils.js
@@ -1,0 +1,6 @@
+const ContrailUtils = {
+  getConfigModelName (viewName) {
+    return viewName.replace('View', 'ConfigModel')
+  }
+}
+module.exports = ContrailUtils

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,7 @@ const config = {
       'contrail-charts-config-model': 'plugins/contrail/ContrailChartsConfigModel',
       'contrail-charts-view': 'plugins/contrail/ContrailChartsView',
       'contrail-charts-events': 'plugins/contrail/ContrailChartsEvents',
+      'contrail-charts-utils': 'plugins/contrail/ContrailChartsUtils',
     },
     extensions: ['', '.js']
   },


### PR DESCRIPTION
Component type is replaced with class name getter.
Chart config to use class name without 'View' for component types.