### PR TITLE
Enable grouped bar in the CompositY example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ And we need to plot a line chart for memory 'mem' data over time 'ts'
               plot: {
                 x: {
                   accessor: 'ts', // Accessor key from dataset to plot x axis
-                  label: 'Time' // Label to be displayed
+                  label: 'Time', // Label to be displayed
+                  axis: 'x'
                 },
                 y: [ // Array of plottable accessors on Y axis
                   {

--- a/examples/basic/basic.js
+++ b/examples/basic/basic.js
@@ -20,14 +20,14 @@ cpuMemChartView.setConfig({
         x: {
           accessor: 'ts',
           label: 'Time',
-          //axis: 'x'
+          axis: 'x'
         },
         y: [
           {
             accessor: 'mem',
             label: 'Memory',
             enabled: true,
-            chart: 'line',
+            chart: 'LineChart',
             color: 'green',
             axis: 'y1'
           },
@@ -35,7 +35,7 @@ cpuMemChartView.setConfig({
             accessor: 'cpu',
             label: 'CPU',
             enabled: true,
-            chart: 'bar',
+            chart: 'BarChart',
             color: 'steelblue',
             axis: 'y2'
           }

--- a/examples/composite-xy/composite-xy.js
+++ b/examples/composite-xy/composite-xy.js
@@ -63,11 +63,11 @@ complexChartView.setConfig({
             accessor: 'a',
             labelFormatter: 'A',
             enabled: true,
-            chart: 'StackedBarChart',
+            chart: 'BarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
-                chart: 'StackedBar'
+                chart: 'StackedBarChart'
               }, {
                 label: 'Bar',
                 chart: 'BarChart'
@@ -82,7 +82,7 @@ complexChartView.setConfig({
             accessor: 'b',
             labelFormatter: 'B',
             enabled: true,
-            chart: 'StackedBarChart',
+            chart: 'BarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',
@@ -101,7 +101,7 @@ complexChartView.setConfig({
             accessor: 'c',
             labelFormatter: 'C',
             enabled: false,
-            chart: 'StackedBarChart',
+            chart: 'BarChart',
             possibleChartTypes: [
               {
                 label: 'Stacked Bar',

--- a/src/js/components/composite-y/ScatterPlotView.js
+++ b/src/js/components/composite-y/ScatterPlotView.js
@@ -27,7 +27,7 @@ class ScatterPlotView extends XYChartSubView {
   }
   /**
   * Called by the parent in order to calculate maximum data extents for all of this child's axis.
-  * Assumes the params.activeAccessorData for this child view is filled by the parent with the relevent yAccessors for this child only.
+  * Assumes the params.activeAccessorData for this child view is filled by the parent with the relevant yAccessors for this child only.
   * Returns an object with following structure: { y1: [0,10], x: [-10,10] }
   */
   calculateAxisDomains () {


### PR DESCRIPTION
- Let's have grouped bar chart by default for compositeY example
- when legendPanel has the chart type switcher enabled, will be able to
  switch to stackedBar on fly